### PR TITLE
Add run on repl.it badge

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "go"
+run = "go build && echo 'Usage: ./uni <command>'"

--- a/README.markdown
+++ b/README.markdown
@@ -1,5 +1,6 @@
 [![Build Status](https://travis-ci.org/arp242/uni.svg?branch=master)](https://travis-ci.org/arp242/uni)
 [![codecov](https://codecov.io/gh/arp242/uni/branch/master/graph/badge.svg)](https://codecov.io/gh/arp242/uni)
+[![Run on repl.it](https://repl.it/badge/github/arp242/uni)](https://repl.it/github/arp242/uni)
 
 `uni` queries the Unicode database from the commandline.
 


### PR DESCRIPTION
Uni seems really cool, it's useful enough to want to run it in the browser too. This adds a "run on repl.it" badge that lets people play around and tinker with the tool on the web. You can try it yourself here: https://repl.it/@amasad/uni

Here is how it looks like:
<img width="1679" alt="Screen Shot 2019-12-12 at 3 51 09 PM" src="https://user-images.githubusercontent.com/587518/70759074-ea350880-1cf9-11ea-9f83-6c6652eb1c47.png">

