### PR TITLE
Fix warnings about uint32 conversion introduced by Go 1.15

### DIFF
--- a/unidata/data.go
+++ b/unidata/data.go
@@ -33,13 +33,13 @@ func (e Emoji) String() string {
 	if (e.Codepoints[0] >= 0x1f1e6 && e.Codepoints[0] <= 0x1f1ff) ||
 		(len(e.Codepoints) > 1 && e.Codepoints[1] == 0xe0067) {
 		for _, cp := range e.Codepoints {
-			c += string(cp)
+			c += string(rune(cp))
 		}
 		return c
 	}
 
 	for i, cp := range e.Codepoints {
-		c += string(cp)
+		c += string(rune(cp))
 
 		// Don't add ZWJ as last item.
 		if i == len(e.Codepoints)-1 {


### PR DESCRIPTION
Instead of directly converting the uint32 to a string, it converts to a
rune first.